### PR TITLE
chore: add missing type hints in oil_prices_flow.py

### DIFF
--- a/oil_prices_flow.py
+++ b/oil_prices_flow.py
@@ -6,7 +6,7 @@ from dataflows import (
 from dataflows import add_metadata, dump_to_path, load, set_type, printer
 
 
-def rename_resources(package: PackageWrapper):
+def rename_resources(package: PackageWrapper) -> None:
     package.pkg.descriptor["resources"][0]["name"] = "brent-daily"
     package.pkg.descriptor["resources"][0]["path"] = "data/brent-daily.csv"
     package.pkg.descriptor["resources"][1]["name"] = "brent-week"
@@ -31,7 +31,7 @@ def rename_resources(package: PackageWrapper):
     yield from package
 
 
-def filter_out_empty_rows(rows):
+def filter_out_empty_rows(rows) -> None:
     for row in rows:
         if row["Date"]:
             yield row


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `oil_prices_flow.py`: added type hints to 2 function(s)

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `oil_prices_flow.py`:**
```diff
-def rename_resources(package: PackageWrapper):
+def rename_resources(package: PackageWrapper) -> None:
-def filter_out_empty_rows(rows):
+def filter_out_empty_rows(rows) -> None:
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

If any of these annotations look off to you, feel free to adjust them or close the PR entirely.